### PR TITLE
docs: fix syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install --save electron-trpc
    import { router, createContext } from './api';
 
    app.on('ready', () => {
-     createIPCHandler({ ipcMain, router, createContext }));
+     createIPCHandler({ ipcMain, router, createContext });
 
      // ...
    });


### PR DESCRIPTION
Fixed a very minor syntax error in the readme.

This PR is more me setting up the project locally and preparing it for the move to v10.
And editing something that caught me while I was copy-pasting.

And it's also because I want to participate in Hacktoberfest, could this be marked as "hacktoberfest-accepted", please 👼?  (or add the topic "hacktoberfest" to the repo if you wish to open it for more contributions.)