### PR TITLE
fix: specify exported types in the exports field

### DIFF
--- a/packages/electron-trpc/package.json
+++ b/packages/electron-trpc/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "author": "Jason Nall <jsonnull@gmail.com>",


### PR DESCRIPTION
TypeScript won't recognize the types specified in the "types" field from `package.json` if using `"moduleResolution": Node16"`. Adding the types entry to the "exports" field works in that scenario.