### PR TITLE
Fix versioning.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["examples/*"]
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
`ignore` didn't behave the way I expected, despite reading the docs for it. Now there'll be prompts over which package to version when running `pnpm changeset`, but at least examples still won't be published since `private: true` is respected.