### PR TITLE
Clean up subscriptions when frames perform navigation.

### DIFF
--- a/.changeset/stale-dogs-collect.md
+++ b/.changeset/stale-dogs-collect.md
@@ -1,0 +1,5 @@
+---
+'electron-trpc': minor
+---
+
+Subscriptions will now be cleaned up when the frame owning that subscription performs a navigation.

--- a/packages/electron-trpc/src/main/handleIPCMessage.ts
+++ b/packages/electron-trpc/src/main/handleIPCMessage.ts
@@ -8,6 +8,9 @@ import { getTRPCErrorFromUnknown } from './utils';
 import { CreateContextOptions } from './types';
 import { ELECTRON_TRPC_CHANNEL } from '../constants';
 import { ETRPCRequest } from '../types';
+import debugFactory from 'debug';
+
+const debug = debugFactory('electron-trpc:main:handleIPCMessage');
 
 export async function handleIPCMessage<TRouter extends AnyRouter>({
   router,
@@ -107,6 +110,7 @@ export async function handleIPCMessage<TRouter extends AnyRouter>({
       },
     });
 
+    debug('Creating subscription', internalId);
     subscriptions.set(internalId, subscription);
   } catch (cause) {
     const error: TRPCError = getTRPCErrorFromUnknown(cause);

--- a/packages/electron-trpc/src/renderer/ipcLink.ts
+++ b/packages/electron-trpc/src/renderer/ipcLink.ts
@@ -4,9 +4,9 @@ import type { TRPCResponseMessage } from '@trpc/server/rpc';
 import type { RendererGlobalElectronTRPC } from '../types';
 import { observable, Observer } from '@trpc/server/observable';
 import { transformResult } from './utils';
-import debug from 'debug';
+import debugFactory from 'debug';
 
-const log = debug('electron-trpc:renderer:ipcLink');
+const debug = debugFactory('electron-trpc:renderer:ipcLink');
 
 type IPCCallbackResult<TRouter extends AnyRouter = AnyRouter> = TRPCResponseMessage<
   unknown,
@@ -47,7 +47,7 @@ class IPCClient {
   }
 
   #handleResponse(response: TRPCResponseMessage) {
-    log('handling response', response);
+    debug('handling response', response);
     const request = response.id && this.#pendingRequests.get(response.id);
     if (!request) {
       return;


### PR DESCRIPTION
Instruments desired cleanup brought up by https://github.com/jsonnull/electron-trpc/issues/164