### PR TITLE
Fix crash when calling .destroy() on a BrowserWindow

### DIFF
--- a/.changeset/giant-pandas-approve.md
+++ b/.changeset/giant-pandas-approve.md
@@ -1,0 +1,5 @@
+---
+'electron-trpc': patch
+---
+
+Fix a crash when calling `.destroy()` on a BrowserWindow.


### PR DESCRIPTION
Fixes a crash that happens when calling `.destroy()` on a BrowserWindow with an electron-trpc handler attached. `detachHandler` can potentially be called with a destroyed window, which then causes a crash on accessing `win.webContents.id`. See #156 for a reproduction case.

Definitely open to alternate solutions here! Feel free to close this PR or push to the branch directly if you'd like any changes.

Closes #156
